### PR TITLE
chore(cypress): ensure server is ready before launching tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7804,6 +7804,12 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
+    "isemail": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+      "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -7936,6 +7942,12 @@
       "requires": {
         "handlebars": "4.0.11"
       }
+    },
+    "items": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
+      "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg=",
+      "dev": true
     },
     "jest": {
       "version": "20.0.4",
@@ -8264,6 +8276,19 @@
         "jest-matcher-utils": "20.0.3",
         "leven": "2.1.0",
         "pretty-format": "20.0.3"
+      }
+    },
+    "joi": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-9.2.0.tgz",
+      "integrity": "sha1-M4WseQGSEwy+Iw6ALsAskhW7/to=",
+      "dev": true,
+      "requires": {
+        "hoek": "4.2.1",
+        "isemail": "2.2.1",
+        "items": "2.1.1",
+        "moment": "2.22.0",
+        "topo": "2.0.2"
       }
     },
     "js-base64": {
@@ -10091,6 +10116,12 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.0.tgz",
       "integrity": "sha512-nJmSswG4As/MkRq7QZFuH/sf/yuv8ODdMZrY4Bedjp77a5MK4A6s7YbBB64c9u79EBUOfXUXBvArmvzTD0X+6g=="
+    },
+    "nice-try": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
+      "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
+      "dev": true
     },
     "no-case": {
       "version": "2.3.2",
@@ -13200,6 +13231,12 @@
         "is-promise": "2.1.0"
       }
     },
+    "rx": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I=",
+      "dev": true
+    },
     "rx-lite": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
@@ -13928,6 +13965,60 @@
       "integrity": "sha1-GpuxMcGIVgECPHqt3T1UwiFCxSY=",
       "dev": true
     },
+    "start-server-and-test": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.4.1.tgz",
+      "integrity": "sha512-qEKGBrOW4B1uWO7sQjluCrCVhscUPOCbyCPLfaZ7m67iOyK8tqZ9B5qZMRPjhedQ14Xcfps6V6CaCGKfjnu3bg==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "check-more-types": "2.24.0",
+        "debug": "3.1.0",
+        "execa": "0.10.0",
+        "lazy-ass": "1.6.0",
+        "ps-tree": "1.1.0",
+        "wait-on": "2.1.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "1.0.4",
+            "path-key": "2.0.1",
+            "semver": "5.5.0",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "6.0.5",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        }
+      }
+    },
     "state-toggle": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.0.tgz",
@@ -14425,6 +14516,15 @@
             "kind-of": "3.2.2"
           }
         }
+      }
+    },
+    "topo": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+      "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+      "dev": true,
+      "requires": {
+        "hoek": "4.2.1"
       }
     },
     "toposort": {
@@ -15041,6 +15141,33 @@
       "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-0.4.0.tgz",
       "integrity": "sha512-itHoJUKL5P8abjhWRlp3F5QLDY7LokcJkgD78tjrX08ozBakfy9YD4bgxUVuSld8yqjza3ld6Sj7UMMOH/twFA==",
       "dev": true
+    },
+    "wait-on": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-2.1.0.tgz",
+      "integrity": "sha512-hDwJ674+7dfiiK/cxtYCwPxlnjXDjto/pCz1PF02sXUhqCqCWsgvxZln0699PReWqXXgkxqkF6DDo5Rj9sjNvw==",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.5",
+        "joi": "9.2.0",
+        "minimist": "1.2.0",
+        "request": "2.83.0",
+        "rx": "4.1.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
+          "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
     },
     "walker": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -61,13 +61,16 @@
     "test:travis:pr": "npm test",
     "test:unit": "cross-env CI=true npm run test:unit:watch",
     "test:unit:watch": "react-scripts --require ./bin/expand-metadatas.js test --env=jsdom",
-    "test:cypress": "npm-run-all build --parallel --race serve cy:run",
-    "test:cypress:travis": "npm-run-all build --parallel --race serve 'cy:run -- --record --config videoRecording=true'",
+    "test:cypress": "npm run build && npm run cy:start-server-and-test",
+    "test:cypress:travis": "npm run build && npm run cy:start-server-and-test:travis",
     "test:cypress:dev": "npm-run-all --parallel --race start 'cy:open -- --config baseUrl=http://localhost:3000'",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
+    "cy:run:travis": "npm run cy:run -- --record --config videoRecording=true",
+    "cy:start-server-and-test": "npx start-server-and-test serve :5000 cy:run",
+    "cy:start-server-and-test:travis": "npx start-server-and-test serve :5000 cy:run:travis",
     "test:precommit": "npm test",
-    "serve": "npx serve build",
+    "serve": "npx serve --port 5000 build",
     "eject": "react-scripts eject",
     "lint": "npx eslint .",
     "pretty": "npx prettier --write '**/*.{js,jsx,json,css,scss}'",
@@ -105,7 +108,8 @@
     "npm-run-all": "^4.1.2",
     "prettier": "1.11.1",
     "react-testing-library": "^2.0.0",
-    "serve": "^6.5.3"
+    "serve": "^6.5.3",
+    "start-server-and-test": "^1.4.1"
   },
   "proxy": {
     "/api/npm-registry": {


### PR DESCRIPTION
As @bahmutov mentioned it on #3, there is an edge case where the server
could "not" be ready when launching tests if using `--race` flag with
`npm-run-all`.

Fixed it using [start-server-and-test](https://github.com/bahmutov/start-server-and-test).

Fixes #3