### PR TITLE
chore(*): upgrade material-ui from 1.0.0-beta.42 to 1.0.0-beta.43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -147,7 +147,7 @@
       "resolved": "https://registry.npmjs.org/@types/jss/-/jss-9.5.2.tgz",
       "integrity": "sha512-EX87yNYcisXO5BU9tT7stB7OGuDJyV3JwtMwhfUprrmHwYKWh9a3vchAy6DYzUSbmTA7bD46h8qata5jP1V7Zw==",
       "requires": {
-        "csstype": "2.2.0",
+        "csstype": "2.3.0",
         "indefinite-observable": "1.0.1"
       }
     },
@@ -176,11 +176,11 @@
       "dev": true
     },
     "@types/react": {
-      "version": "16.3.11",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.11.tgz",
-      "integrity": "sha512-F0ZqVldV6l7FObRPfkgXg4GwWJa4tGrh1glydmx+OMOdU4K5lUnh2rlj/4uO6RnuN2OBVCzo2XiyIifEZPkCXw==",
+      "version": "16.3.12",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.3.12.tgz",
+      "integrity": "sha512-FfBhLC3QeXXEtjoGGLixS7cB305vzBOM1dZKtbUuXeTfjY0quzRRMxpqylC4QyUaLqdhNLdER0ZdHUGAVlGSCA==",
       "requires": {
-        "csstype": "2.2.0"
+        "csstype": "2.3.0"
       }
     },
     "@types/react-transition-group": {
@@ -188,7 +188,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-2.0.8.tgz",
       "integrity": "sha512-52rCkAlhkFfaXplkujWUevTMb9/DCsND1DwB6VONPJKAShC3MrRl130ADV7Rc+7t83KVAoz4HPFhJuHI5pfnZA==",
       "requires": {
-        "@types/react": "16.3.11"
+        "@types/react": "16.3.12"
       }
     },
     "@types/sinon": {
@@ -3257,9 +3257,9 @@
       }
     },
     "csstype": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.2.0.tgz",
-      "integrity": "sha512-5YHWQgAtzKIA8trr2AVg6Jq5Fs5eAR1UqKbRJjgQQevNx3IAhD3S9wajvqJdmO7bgIxy0MA5lFVPzJYjmMlNeQ=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.3.0.tgz",
+      "integrity": "sha512-+iowf+HbYUKV65+HjAhXkx4KH6IFpIxnBlO0maKsXmBIHJXEndaTRYPVL4pEwtK6+1zRvkXo+WD1tRFKygMHQg=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -9747,9 +9747,9 @@
       "integrity": "sha1-GZTfLTr0gR3lmmcUk0wrIpJzRRg="
     },
     "material-ui": {
-      "version": "1.0.0-beta.42",
-      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-1.0.0-beta.42.tgz",
-      "integrity": "sha512-b8eniowlv5dKU5eyrCnh9SP/NXxm2QE/kECvv+QNhkvDFdSL8QPmOTJjP2ytF1ghapRwJal+Ld2tBt+gKng/DA==",
+      "version": "1.0.0-beta.43",
+      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-1.0.0-beta.43.tgz",
+      "integrity": "sha512-6prcG6pwOBAH3s44GJg1WiylByz/TSL6oXlDXnBW1Sb0mSjL1ezfdZj4nSO2qjrPyfDm9sjwxaR9ZoVIHxU17g==",
       "requires": {
         "@types/jss": "9.5.2",
         "@types/react-transition-group": "2.0.8",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "hoist-non-react-statics": "^2.5.0",
     "invariant": "^2.2.3",
     "js-md5": "^0.7.3",
-    "material-ui": "^1.0.0-beta.42",
+    "material-ui": "^1.0.0-beta.43",
     "prop-types": "^15.6.1",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",


### PR DESCRIPTION
Now using latest [material-ui version](https://github.com/mui-org/material-ui/releases/tag/v1.0.0-beta.43) 😉@oliviertassinari