### PR TITLE
chore(travis): fix cypress error - missing library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ sudo: false
 language: node_js
 node_js:
   - "8"
+addons:
+  apt:
+    packages:
+      - libgconf-2-4
 jobs:
   include:
     - stage: Testing / Deploy (staging/production)


### PR DESCRIPTION
Following error in build https://travis-ci.org/topheman/npm-registry-browser/builds/640826657

```
/home/travis/.cache/Cypress/3.1.0/Cypress/Cypress: error while loading shared libraries: libgconf-2.so.4: cannot open shared object file: No such file or directory
```

Solution found: https://github.com/cypress-io/cypress/issues/4069